### PR TITLE
updates to connectinject for >30.0 helm chart

### DIFF
--- a/helm/consul-values-gke.yaml
+++ b/helm/consul-values-gke.yaml
@@ -29,9 +29,12 @@ ui:
 connectInject:
   enabled: true
   default: true
-  centralConfig:
-    enabled: true
-    defaultProtocol: "http"
+  client:
+    extraConfig: |
+      {"enable_central_service_config": true}
+  server:
+    extraConfig: |
+      {"enable_central_service_config": true}
 meshGateway:
   enabled: true
 ingressGateways:


### PR DESCRIPTION
Haris-MacBook:~ hariram$ helm search repo hashicorp/consul
NAME            	CHART VERSION	APP VERSION	DESCRIPTION
hashicorp/consul	0.31.1       	1.9.4      	Official HashiCorp Consul Chart
Haris-MacBook:~ hariram$ helm install -f consul-multicluster-servicemesh/helm/consul-values-gke.yaml consul hashicorp/consul  --wait -n multicluster-servicemesh
Error: template: consul/templates/connect-inject-deployment.yaml:6:109: executing "consul/templates/connect-inject-deployment.yaml" at <fail "connectInject.centralConfig.defaultProtocol is no longer supported; instead you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)">: error calling fail: connectInject.centralConfig.defaultProtocol is no longer supported; instead you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)
Haris-MacBook:~ hariram$