### PR TITLE
update to accomodate for >30.0 helm version

### DIFF
--- a/helm/consul-values-eks.yaml
+++ b/helm/consul-values-eks.yaml
@@ -41,8 +41,11 @@ ui:
 connectInject:
   enabled: true
   default: true
-  centralConfig:
-    enabled: true
-    defaultProtocol: "http"
+  client:
+    extraConfig: |
+      {"enable_central_service_config": true}
+  server:
+    extraConfig: |
+      {"enable_central_service_config": true}
 meshGateway:
   enabled: true


### PR DESCRIPTION
"Error: template: consul/templates/connect-inject-deployment.yaml:6:109: executing "consul/templates/connect-inject-deployment.yaml" at <fail "connectInject.centralConfig.defaultProtocol is no longer supported; instead you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)">: error calling fail: connectInject.centralConfig.defaultProtocol is no longer supported; instead you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)"